### PR TITLE
fix(Makefile): Simplified Makefile (one cert for all container)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 node_modules/
 cert/
+certificate/
 *.lock
 *.sqlite
 uploads/

--- a/Makefile
+++ b/Makefile
@@ -1,69 +1,34 @@
+COMPOSE := docker compose
 COMPOSE_FILE := docker-compose.yaml
 # COMPOSE_PROJECT_NAME := ft_transcendence
-COMPOSE := docker compose
+export COMPOSE COMPOSE_FILE COMPOSE_PROJECT_NAME
 
-export COMPOSE_FILE COMPOSE_PROJECT_NAME
+SERVICES := $(shell docker compose config --services | sed 's/^/DNS:/' | paste -sd ',' -)
 
-.PHONY: all
 all: up
 
-.PHONY: up
-up: cert dbDir uploadsDir
+up: volume_path certificate
 	$(COMPOSE) up --build --detach
 
-.PHONY: cert
-cert: cert/privatekey.pem cert/certificate.pem
-
-dbDir:
+volume_path:
 	@mkdir -p ./database
-uploadsDir:
 	@mkdir -p ./frontend/static/uploads
 
-cert/privatekey.pem cert/certificate.pem:
+certificate: certificate/privatekey.pem certificate/certificate.pem
+certificate/privatekey.pem certificate/certificate.pem:
 	@mkdir -p $(dir $@)
-	@openssl req -newkey rsa:2048 -nodes -keyout cert/privatekey.pem -x509 -days 365 -out cert/certificate.pem \
-		-subj "/CN=internal" -addext "subjectAltName=DNS:localhost" 2>/dev/null
+	@openssl req -newkey rsa:2048 -nodes -keyout certificate/privatekey.pem -x509 -days 365 -out certificate/certificate.pem \
+		-subj "/CN=internal" -addext "subjectAltName=DNS:localhost,$(SERVICES)" 2>/dev/null
+	@chmod 644 certificate/*	# Very important for grafana and prometheus because they run as own user
 	@echo "=> New certs has been generated"
 
-.PHONY: services-cert
-services-cert: services/tournament/cert services/game/cert services/queue/cert services/chat/cert 
-
-.PHONY: services/tournament/cert
-services/tournament/cert:
-	@mkdir -p $@
-	@openssl req -newkey rsa:2048 -nodes -keyout $@/privatekey.pem -x509 -days 365 -out $@/certificate.pem \
-		-subj "/CN=internal" -addext "subjectAltName=DNS:tournament-service" 2>/dev/null
-
-.PHONY: services/game/cert
-services/game/cert:
-	@mkdir -p $@
-	@openssl req -newkey rsa:2048 -nodes -keyout $@/privatekey.pem -x509 -days 365 -out $@/certificate.pem \
-		-subj "/CN=internal" -addext "subjectAltName=DNS:game-service" 2>/dev/null
-
-.PHONY: services/queue/cert
-services/queue/cert:
-	@mkdir -p $@
-	@openssl req -newkey rsa:2048 -nodes -keyout $@/privatekey.pem -x509 -days 365 -out $@/certificate.pem \
-		-subj "/CN=internal" -addext "subjectAltName=DNS:queue-service" 2>/dev/null
-
-.PHONY: services/chat/cert
-services/chat/cert:
-	@mkdir -p $@
-	@openssl req -newkey rsa:2048 -nodes -keyout $@/privatekey.pem -x509 -days 365 -out $@/certificate.pem \
-		-subj "/CN=internal" -addext "subjectAltName=DNS:chat-service" 2>/dev/null
-
-.PHONY: build
 build:
 	$(COMPOSE) build
 
-.PHONY: down
 down:
-	$(COMPOSE) down --timeout 2
+	$(COMPOSE) down
 
-.PHONY: ps
 ps:
 	$(COMPOSE) ps
 
-.PHONY: tailwind
-tailwind: up
-	docker exec -it frontend npx tailwindcss -i src/input.css -o static/tailwind.css
+.PHONY: all up certificate build down ps

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
     volumes:
       - chat-service-src:/srv/app/src
       - backend-db:/srv/app/db
-      - chat-service-cert:/run/secrets:ro
+      - cert:/run/secrets:ro
     env_file: .env
 
   friend-service:
@@ -54,7 +54,7 @@ services:
     volumes:
       - game-service-src:/srv/app/src
       - backend-db:/srv/app/db
-      - game-service-cert:/run/secrets:ro
+      - cert:/run/secrets:ro
     env_file: .env
 
   queue-service:
@@ -65,7 +65,7 @@ services:
     volumes:
       - queue-service-src:/srv/app/src
       - backend-db:/srv/app/db
-      - queue-service-cert:/run/secrets:ro
+      - cert:/run/secrets:ro
     env_file: .env
 
   tournament-service:
@@ -76,7 +76,7 @@ services:
     volumes:
       - tournament-service-src:/srv/app/src
       - backend-db:/srv/app/db
-      - tournament-service-cert:/run/secrets:ro
+      - cert:/run/secrets:ro
     env_file: .env
 
   user-service:
@@ -100,10 +100,6 @@ services:
       - websocket-service-src:/srv/app/src
       - backend-db:/srv/app/db
       - cert:/run/secrets:ro
-      - tournament-service-cert:/run/cert/tournament:ro
-      - queue-service-cert:/run/cert/queue:ro
-      - game-service-cert:/run/cert/game:ro
-      - chat-service-cert:/run/cert/chat:ro
     env_file: .env
 
   # grafana:
@@ -201,12 +197,6 @@ volumes:
       device: ./services/chat/src
       type: none
       o: bind
-  chat-service-cert:
-    driver: local
-    driver_opts:
-      device: ./services/chat/cert
-      type: none
-      o: bind
 
   friend-service-src:
     driver: local
@@ -221,12 +211,6 @@ volumes:
       device: ./services/game/src
       type: none
       o: bind
-  game-service-cert:
-    driver: local
-    driver_opts:
-      device: ./services/game/cert
-      type: none
-      o: bind
 
   queue-service-src:
     driver: local
@@ -234,23 +218,11 @@ volumes:
       device: ./services/queue/src
       type: none
       o: bind
-  queue-service-cert:
-    driver: local
-    driver_opts:
-      device: ./services/queue/cert
-      type: none
-      o: bind
 
   tournament-service-src:
     driver: local
     driver_opts:
       device: ./services/tournament/src
-      type: none
-      o: bind
-  tournament-service-cert:
-    driver: local
-    driver_opts:
-      device: ./services/tournament/cert
       type: none
       o: bind
 
@@ -267,12 +239,6 @@ volumes:
       device: ./services/websocket/src
       type: none
       o: bind
-  websocket-service-cert:
-    driver: local
-    driver_opts:
-      device: ./services/websocket/cert
-      type: none
-      o: bind
 
   backend-db:
     driver: local
@@ -283,7 +249,7 @@ volumes:
   cert:
     driver: local
     driver_opts:
-      device: ./cert
+      device: ./certificate
       type: none
       o: bind
   uploads:

--- a/services/websocket/src/router.ts
+++ b/services/websocket/src/router.ts
@@ -22,10 +22,12 @@ export default function(user: tables.User, ws: WebSocket.WebSocket) {
 	services.set(user.uuid, new ClientServices(user.uuid, ws));
 }
 
-const serviceList = ["tournament", "chat", "queue", "game"].map(name => {
+const agent = new https.Agent({ ca: fs.readFileSync(`/run/secrets/certificate.pem`), rejectUnauthorized: false });
+
+const serviceList = ["auth", "tournament", "chat", "queue", "game"].map(name => {
 	return {
 		name: name,
-		agent: new https.Agent({ ca: fs.readFileSync(`/run/cert/${name}/certificate.pem`), rejectUnauthorized: false }),
+		agent
 	};
 });
 


### PR DESCRIPTION
Makefile is now much simpler and readable. All .PHONY have been moved in one to the end. Just on certificate in generated for all service, with all DNS entry in one. Deleted per-service certificate volume in docker-compose.